### PR TITLE
Handle package names case-insenstively.

### DIFF
--- a/lib/PAUSE/Permissions/ModuleIterator.pm
+++ b/lib/PAUSE/Permissions/ModuleIterator.pm
@@ -52,7 +52,7 @@ sub next_module
             $line =~ s/[\r\n]+$//;
             my ($module, $user, $permission) = split(/,/, $line);
             $user = uc($user);
-            if (defined($current_module) && $module ne $current_module) {
+            if (defined($current_module) && lc($module) ne lc($current_module)) {
                 $self->_cached_line($line);
                 my $module_name = $current_module;
                 $current_module = undef;

--- a/t/05-preload.t
+++ b/t/05-preload.t
@@ -8,6 +8,7 @@ use PAUSE::Permissions;
 
 my $NO_MODULE_RENDER = '||module=undef||owner=undef||co-maints=||';
 my %TESTS = (
+    'Apache::Test'         => '||module=Apache::Test||owner=APML||co-maints=APML,DOUGM,DOUGM,GEOFF||',
     'constant'             => '||module=constant||owner=SAPER||co-maints=P5P,PERL||',
     'constant::Atom'       => '||module=constant::Atom||owner=JOHNWRDN||co-maints=NEILB||',
     'Math::Complex'        => '||module=Math::Complex||owner=RAM||co-maints=JHI,PERL,ZEFRAM||',

--- a/t/06perms-mini.txt
+++ b/t/06perms-mini.txt
@@ -13,3 +13,8 @@ Math::Complex,perl,c
 CPAN::Test::Reporter,SKUD,c
 Test::Cucumber,JOHND,f
 Test::Cucumber,SARGIE,m
+Apache::Test,APML,f
+Apache::test,APML,m
+Apache::Test,DOUGM,c
+Apache::test,DOUGM,c
+Apache::Test,GEOFF,c


### PR DESCRIPTION
This was done for version 0.08 for issues #1 and #2 on github,
but not when you did a preload.

Note that there may be more needed for this fix.  I'm wondering
if the lines are getting sorted in odd ways.

Note the odd results with the permissions I've passed in.  I have a suspicion that there is some line sorting going on with the file that also needs some fixing (or perhaps removing?).